### PR TITLE
Fix 2D interpolation in xspec module

### DIFF
--- a/xspec/calc_xscat.cxx
+++ b/xspec/calc_xscat.cxx
@@ -84,7 +84,7 @@ void calc_xscat(const RealArray& energyArray,
       xl_wt*rl_wt*xscat_dat->sigma[iE + xl*Nrext + rl] +
       xl_wt*rh_wt*xscat_dat->sigma[iE + xl*Nrext + rh] + 
       xh_wt*rl_wt*xscat_dat->sigma[iE + xh*Nrext + rl] +
-      xh_wt*rl_wt*xscat_dat->sigma[iE + xh*Nrext + rh];
+      xh_wt*rh_wt*xscat_dat->sigma[iE + xh*Nrext + rh];
     /* printf("Sval: %e %e %e\n", Eval[ii], Sval[ii], 
        xscat_dat->sigma[iE + xl*Nrext + rh]); */
   }


### PR DESCRIPTION
Previously, the wrong weight for the radius was used for the grid point at high radius and screen distance.